### PR TITLE
og:title can either be from the HTMl title, h1, or h2

### DIFF
--- a/admin/tool/urlpreview/templates/metadata.mustache
+++ b/admin/tool/urlpreview/templates/metadata.mustache
@@ -1,8 +1,3 @@
-{{#noogmetadata}}
-  <p>No Open Graph metadata available.</p>
-{{/noogmetadata}}
-
-{{^noogmetadata}}
 <table class="table table-sm table-bordered">
     <tr>
         <th>Property</th>
@@ -84,5 +79,4 @@
         <td>{{#description}}{{.}}{{/description}}{{^description}}<i>Not available</i>{{/description}}</td>
     </tr>
 </table>
-{{/noogmetadata}}
 

--- a/lib/classes/url/unfurler.php
+++ b/lib/classes/url/unfurler.php
@@ -41,8 +41,15 @@ class unfurl {
         //set default values
         //default html title
         $titleElement = $doc->getElementsByTagName('title')->item(0);
+        $h1Element = $doc->getElementsByTagName('h1')->item(0);
+        $h2Element = $doc->getElementsByTagName('h2')->item(0);
+
         if ($titleElement) {
             $this->title = $titleElement->textContent;
+        } elseif ($h1Element) {
+            $this->title = $h1Element->textContent;
+        } elseif ($h2Element) {
+            $this->title = $h2Element->textContent;
         }
 
         //iterate through meta tags


### PR DESCRIPTION
unfurler.php
- added "default" values for the title variable
- this checks for the HTML title, h1 or h2

metadata.mustache
- I removed the noogmetadata check, as the template would not render the table at all if there were no metadata
- Even though there could be default titles that were grabbed from the HTML title, h1, or h2
- the noogmetadata variable is only marked as true when there is an actual value, ignoring the "defaults"

Output in Moodle 
- If the title is present, the title is displayed in the "og:title" cell, is this misleading as the title scraped from somewhere else (HTML title, h1, or h2)

Tested with the following:
- https://catalyst-qut-2023.github.io/04-no-title-only-h1.html
- https://catalyst-qut-2023.github.io/05-no-title-h1-and-h2.html (h1 takes precedence over h2)
- https://catalyst-qut-2023.github.io/06-no-title-only-h2.html